### PR TITLE
Some tweaks

### DIFF
--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -97,7 +97,6 @@ while read luksid; do
     cryptsetup luksHeaderBackup "/dev/disk/by-uuid/$luksid" \
                --header-backup-file "$LUKS_HEADER_DUMP"
     luks_header_hash=$(sha1sum "$LUKS_HEADER_DUMP" | cut -f 1 -d ' ')
-    rm -f "$LUKS_HEADER_DUMP"
     log "Extending PCR $LUKS_PCR, value $luks_header_hash, device $luksid..."
     tpm_pcr_extend "$LUKS_PCR" "$luks_header_hash"
 done
@@ -154,8 +153,6 @@ else
     log "Freshness token invalid!"
     exit 1
 fi
-
-rm -f /tmp/fresh
 
 
 # check for OTP
@@ -235,8 +232,6 @@ if otp; then
                 tout=30
             done
         fi
-
-        rm -f "$UNSEALED_SECRET"
     else
         # unsealing OTP seed failed, don't even search for keyfile
         alias otp=false
@@ -291,9 +286,6 @@ if tpm_unsealdata $Z -i "$SEALED_SECRET" -o "$UNSEALED_SECRET" \
         waitforenter
     fi
 fi
-
-
-rm -f "$UNSEALED_SECRET"
 
 
 # Clear all messages to hide the secret. Do it even if the unsealing has

--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -86,6 +86,10 @@ tcsd
 log "Unmounting the $LABEL device..."
 umount "$MNT"
 
+if [ "$(blockdev --getro "$DEV")" = 1 ]; then
+    message "You should now unplug the AEM device if it is intentionally read-only."
+fi
+
 
 # Extend PCR with LUKS header(s)
 
@@ -163,13 +167,6 @@ if [ -e "$sealed_secret_otp" ]; then
 else
     alias otp=false
 fi
-
-
-# tell user to remove AEM dev if RO
-
-message ""
-message "You should now unplug the AEM device if it's read-only."
-message ""
 
 
 # unseal & show OTP if provisioned

--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -142,6 +142,7 @@ log "Unsealing freshness token..."
 if tpm_unsealdata $Z -i "$sealed_secret_fsh" -o /tmp/fresh \
         < "$SRK_PASSWORD_CACHE"; then
     log "Freshness token unsealed."
+    touch "$CACHE_DIR/unseal-success"
 else
     log "Freshness token unsealing failed!"
     exit 1

--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -16,10 +16,18 @@ LUKS_PCR=13
 
 
 PLYMOUTH_MESSAGES=()
+
 plymouth_message() {
     plymouth message --text="$*"
     PLYMOUTH_MESSAGES+=("$*")
 }
+
+plymouth_messages_hide() {
+    for m in "${PLYMOUTH_MESSAGES[@]}"; do
+        plymouth hide-message --text="$m"
+    done
+}
+
 . anti-evil-maid-lib
 
 
@@ -127,7 +135,8 @@ else
     for try in 1 2 3; do
         log "Prompting for SRK password..."
 
-        if systemd-ask-password "TPM SRK password to unseal the secret" |
+        if systemd-ask-password --timeout=0 \
+                                "TPM SRK password to unseal the secret(s)" |
            tee "$SRK_PASSWORD_CACHE" |
            tpm_sealdata -i /dev/null -o /dev/null; then
              log "Correct SRK password"
@@ -159,145 +168,88 @@ else
 fi
 
 
-# check for OTP
+# unseal & show OTP if provisioned
+# unseal & decrypt key file unless the user switches to text secret mode
 
 if [ -e "$sealed_secret_otp" ]; then
     alias otp=true
-    SEALED_SECRET=$sealed_secret_otp
 else
     alias otp=false
 fi
 
-
-# unseal & show OTP if provisioned
-
 if otp; then
     log "Unsealing TOTP shared secret seed..."
-    if tpm_unsealdata $Z -i "$SEALED_SECRET" -o "$UNSEALED_SECRET" \
+    if tpm_unsealdata $Z -i "$sealed_secret_otp" -o "$UNSEALED_SECRET" \
             < "$SRK_PASSWORD_CACHE"; then
         log "TOTP secret unsealed."
-        seed=$(cat "$UNSEALED_SECRET")
 
-        message "Please verify your OTP device displays the same TOTP code"
-        message "as shown below. Should the codes match, press <ENTER> to"
-        message "unseal your LUKS key file. If you do not have access to"
-        message "your OTP device but wish to continue despite the security"
-        message "implications, press <ENTER>. Pressing <T> will revert"
-        message "back to displaying the text secret (if provisioned)."
-        message "Otherwise, shut down the computer."
+        message "Never type in your key file password unless the code below is correct!"
         message ""
-        message "[ $(date) ] TOTP code: $(oathtool --totp -b "$seed")"
-        last=$(date +%s)
 
-        if plymouth_active; then
-            plymouth watch-keystroke --keys=$'\n' \
-                --command='touch /tmp/mfa-cont' &
-            plymouth watch-keystroke --keys=Tt \
-                --command='touch /tmp/mfa-skip' &
-            while [ ! -e /tmp/mfa-cont ] && [ ! -e /tmp/mfa-skip ]; do
-                now=$(date +%s)
-                if [ "$((now % 30))" -eq 0 ] && [ ! "$last" == "$now" ]; then
-                    code=$(oathtool --totp -b "$seed")
-                    message "[ $(date) ] TOTP code: $code"
-                    last=$now
-                else
-                    sleep 0.1
-                fi
-            done
+        seed=$(cat "$UNSEALED_SECRET")
+        last=
+        while :; do
+            trap 'plymouth_messages_hide; exit' TERM
 
-            if [ -e /tmp/mfa-skip ]; then
-                alias otp=false
-                message "Reverting back to non-multi-factor AEM boot"
+            now=$(date +%s)
+            if [ -z "$last" -o "$((now % 30))" = 0 -a "$last" != "$now" ]; then
+                code=$(oathtool --totp -b "$seed")
+                message "[ $(date) ] TOTP code: $code"
+                last=$now
             fi
-        else
-            tout=$((30 - ($(date +%s) % 30)))
-            while true; do
-                msg="Press <ENTER> to continue or <T> + <ENTER>"
-                msg="$msg to skip multi-factor AEM."
-                if systemd-ask-password --echo --timeout "$tout" \
-                        "$msg" \
-                        >/tmp/mfa-resp; then
-                    if grep -qi t /tmp/mfa-resp; then
-                        alias otp=false
-                        message "Reverting back to non-multi-factor AEM boot"
-                    fi
+            sleep 0.1
+        done &
+        totp_loop_pid=$!
+
+        if tpm_unsealdata $Z -i "$sealed_secret_key" -o "$UNSEALED_SECRET" \
+           <"$SRK_PASSWORD_CACHE"; then
+            for try in 1 2 3; do
+                pass=$(systemd-ask-password --timeout=0 \
+                       'LUKS key file password (or "t" to show text secret)')
+
+                if [ "$pass" = "t" ]; then
+                    alias otp=false
                     break
                 fi
 
-                code=$(oathtool --totp -b "$seed")
-                message "[ $(date) ] TOTP code: $code"
-                tout=30
+                if scrypt dec -P "$UNSEALED_SECRET" /tmp/aem-keyfile \
+                   <<<"$pass"; then
+                    log "Correct LUKS key file password"
+                    # dracut "90crypt" module will parse the
+                    #   rd.luks.key=/tmp/aem-keyfile
+                    # kernel cmdline arg and attempt to use it;
+                    # this file is deleted on root switch
+                    # along with everything in /tmp
+                    break
+                else
+                    log "Wrong LUKS key file password"
+                fi
             done
         fi
-    else
-        # unsealing OTP seed failed, don't even search for keyfile
-        alias otp=false
+
+        kill "$totp_loop_pid"
     fi
 fi
 
 
-# determine which secret to use next
+# unseal text secret
 
-if otp; then
-    # user does not want to skip multi-factor AEM
-    SEALED_SECRET=$sealed_secret_key
-    # not checking key file existence since we DO NOT want
-    # the static secrets to be displayed anyway
-else
-    SEALED_SECRET=$sealed_secret_txt
-fi
-
-
-# unseal the next secret
-
-log "Unsealing the secret $SEALED_SECRET..."
-if tpm_unsealdata $Z -i "$SEALED_SECRET" -o "$UNSEALED_SECRET" \
+if ! otp; then
+    log "Unsealing text secret..."
+    if tpm_unsealdata $Z -i "$sealed_secret_txt" -o "$UNSEALED_SECRET" \
         <"$SRK_PASSWORD_CACHE"; then
-    if otp; then
-        # ask for LUKS key file passphrase
-        for try in 1 2 3; do
-            if systemd-ask-password "LUKS key file password" |
-                    scrypt dec -P "$UNSEALED_SECRET" /tmp/aem-keyfile; then
-                log "Correct LUKS key file password"
-                message "Key file decrypted."
-                # decrypted key file saved in /tmp/aem-keyfile;
-                # dracut "90crypt" module will parse the
-                #   rd.luks.key=/tmp/aem-keyfile
-                # kernel cmdline arg and attempt to use it;
-                # this file is deleted on root switch
-                # along with everything in /tmp
-                break
-            else
-                log "Wrong LUKS key file password"
-            fi
-        done
-    else
-        # display txt secret in current dialog
         {
             message ""
             message "$(cat "$UNSEALED_SECRET" 2>/dev/null)"
             message ""
         } 2>&1  # don't put the secret into the journal
-        message "Never type in your disk password unless"
-        message "the secret above is correct!"
+        message "Never type in your disk password unless the secret above is correct!"
         waitforenter
     fi
+
+    plymouth_messages_hide
+    clear
 fi
-
-
-# Clear all messages to hide the secret. Do it even if the unsealing has
-# failed, because that's how an attacker would likely behave to trick
-# absentminded users into thinking that they've already seen the secret.
-# (See AEM introductory blog post FAQ, "Why are there no negative
-# indicators")
-
-if plymouth_active; then
-    for m in "${PLYMOUTH_MESSAGES[@]}"; do
-        plymouth hide-message --text="$m"
-    done
-fi
-
-clear
 
 
 # prevent sealing service from starting if user unplugged

--- a/anti-evil-maid/90anti-evil-maid/module-setup.sh
+++ b/anti-evil-maid/90anti-evil-maid/module-setup.sh
@@ -25,7 +25,6 @@ install() {
         clear \
         cut \
         date \
-        diff \
         file \
         /usr/share/misc/magic \
         grep \
@@ -39,7 +38,6 @@ install() {
         scrypt \
         seq \
         sha1sum \
-        sha256sum \
         sort \
         tail \
         tcsd \

--- a/anti-evil-maid/90anti-evil-maid/module-setup.sh
+++ b/anti-evil-maid/90anti-evil-maid/module-setup.sh
@@ -22,6 +22,7 @@ install() {
     dracut_install \
         /usr/sbin/anti-evil-maid-lib \
         base32 \
+        blockdev \
         clear \
         cut \
         date \

--- a/anti-evil-maid/README
+++ b/anti-evil-maid/README
@@ -184,10 +184,9 @@ downloaded, which records the Xen, kernel, and initrd versions used in PCRs
 launch fails for any reason, tboot will fall back to a normal boot and AEM
 will not function.
 
-a) Enter your SRK password if prompted in case you have set one in step
-3. You won't see your secret afterwards, because it hasn't been sealed
-yet. Enter your disk decryption passphrase anyway, right now you still
-trust your system.
+a) Enter your SRK password if prompted. You won't see your secret afterwards,
+because it hasn't been sealed yet. Enter your disk decryption passphrase
+anyway, right now you still trust your system.
 
 As the system continues booting, AEM will automatically seal your
 secret(s). You should see a line, or multiple lines, like this one:
@@ -205,7 +204,7 @@ them and you want to reseal immediately, run anti-evil-maid-seal manually
 once.
 
 If you get a message that the "PCR sanity check failed" and you are sure you
-have saved the right SINIT blob in step 4.a, then check the tboot log for
+have saved the right SINIT blob in step 3.a, then check the tboot log for
 details. The easiest way to view it is to set "logging=vga vga_delay=10" on
 the "multiboot /tboot.gz" line in grub.cfg and reboot. Alternatively, run
 `sudo txt-stat` from dom0. For more information, see the tboot readme
@@ -217,7 +216,7 @@ b) If a chunk of your installed RAM seems to be missing after the reboot
 # echo 'export GRUB_CMDLINE_TBOOT=min_ram=0x2000000' >>/etc/default/grub
 # grub2-mkconfig -o /boot/grub2/grub.cfg
 
-Then go to step 5.a again. A discussion of this problem can be found at
+Then go to step 4.a again. A discussion of this problem can be found at
 http://thread.gmane.org/gmane.comp.boot-loaders.tboot.devel/610/focus=611
 and by searching for "min_ram" in the qubes mailing lists.
 
@@ -231,7 +230,7 @@ Xen/kernel/BIOS/firmware upgrades
 After Xen, kernel, BIOS, or firmware upgrades, you will need to reboot
 and enter your disk decryption passphrase even though you can't see your
 secret. It will be resealed again automatically later in the boot process
-(see step 5.a).
+(see step 4.a).
 
 
 What to do in case of compromise

--- a/anti-evil-maid/sbin/anti-evil-maid-lib
+++ b/anti-evil-maid/sbin/anti-evil-maid-lib
@@ -68,7 +68,7 @@ waitforenter() {
         message "$msg"
         plymouth watch-keystroke --keys=$'\n'
     else
-        systemd-ask-password "$msg" >/dev/null
+        systemd-ask-password --timeout=0 "$msg" >/dev/null
     fi
 }
 

--- a/anti-evil-maid/sbin/anti-evil-maid-seal
+++ b/anti-evil-maid/sbin/anti-evil-maid-seal
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -o pipefail
+set -e -o pipefail -o errtrace
 shopt -s expand_aliases
 
 # Listing tcsd.service in anti-evil-maid-seal.service's Requires= and After=

--- a/anti-evil-maid/sbin/anti-evil-maid-seal
+++ b/anti-evil-maid/sbin/anti-evil-maid-seal
@@ -30,8 +30,8 @@ trap '_failure $LINENO' ERR
 source /etc/anti-evil-maid.conf
 Z=$(tpm_z_srk)
 
-
-LABEL=$LABEL_PREFIX${1-$(cat "$SUFFIX_CACHE")}
+LABEL_SUFFIX=${1-$(cat "$SUFFIX_CACHE")}
+LABEL=$LABEL_PREFIX$LABEL_SUFFIX
 DEV=/dev/disk/by-label/$LABEL
 
 
@@ -50,7 +50,7 @@ fi
 # regenerate the freshness token and store it's hash in TPM
 
 head -c 20 /dev/random > "$AEM_DIR/$LABEL/secret.fsh"
-updatefreshness "$AEM_DIR/$LABEL/secret.fsh" "${1-$(cat "$SUFFIX_CACHE")}"
+updatefreshness "$AEM_DIR/$LABEL/secret.fsh" "$LABEL_SUFFIX"
 
 
 # seal and save secret(s) to root partition

--- a/anti-evil-maid/sbin/anti-evil-maid-seal
+++ b/anti-evil-maid/sbin/anti-evil-maid-seal
@@ -28,7 +28,14 @@ trap '_failure $LINENO' ERR
 # define sealing and device variables
 
 source /etc/anti-evil-maid.conf
-Z=$(tpm_z_srk)
+
+if   [ -s "$SRK_PASSWORD_CACHE" ]; then
+    Z=
+elif [ -e "$SRK_PASSWORD_CACHE" ]; then
+    Z=-z
+else
+    Z=$(tpm_z_srk)  # can trigger dictionary attack lock if run too often
+fi
 
 LABEL_SUFFIX=${1-$(cat "$SUFFIX_CACHE")}
 LABEL=$LABEL_PREFIX$LABEL_SUFFIX

--- a/anti-evil-maid/sbin/anti-evil-maid-seal
+++ b/anti-evil-maid/sbin/anti-evil-maid-seal
@@ -71,6 +71,10 @@ for ext in txt key otp fsh; do
 
     if [ ! -e "$input" ]; then
         message "Absent $input"
+    elif [ -e "$CACHE_DIR"/unseal-success \
+           -a "$output" -nt "$input" \
+           -a "$output" -nt /etc/anti-evil-maid.conf ]; then
+        message "Skipped $input (already sealed)"
     elif if [ ! -t 0 ]; then cat "$SRK_PASSWORD_CACHE"; fi |
          tpm_sealdata $Z $SEAL -i "$input" -o "$output"; then
         rm -f "${output%2}"

--- a/anti-evil-maid/systemd/system/anti-evil-maid-seal.service
+++ b/anti-evil-maid/systemd/system/anti-evil-maid-seal.service
@@ -12,6 +12,7 @@ ExecStart=/usr/sbin/anti-evil-maid-seal
 Type=oneshot
 StandardOutput=journal+console
 StandardError=inherit
+TimeoutStartSec=300
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Here's a couple of patches, mostly addressing some small stuff I noticed during testing. And a less obvious one (the last commit), which unifies the Plymouth and non-Plymouth code paths for `.otp`/`.key` handling in `-unseal`. It does this by immediately showing the key file password prompt and switching to fallback mode if `t` is entered there. Kind of a hack, but it gets rid of one step for the normal case during boot, and removes a nice chunk of code. I'd be interested if this looks okay to (and works for) you.

Other than that, I feel like we should probably continue testing for a few more days, and try to trigger various error conditions and corner cases to ensure that they are handled correctly.