### PR TITLE
More tweaks

### DIFF
--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -151,7 +151,7 @@ fi
 # check freshness token
 
 log "Unsealing freshness token..."
-if tpm_unsealdata $Z -i "$sealed_secret_fsh" -o /tmp/fresh \
+if tpm_unsealdata $Z -i "$sealed_secret_fsh" -o "$UNSEALED_SECRET" \
         < "$SRK_PASSWORD_CACHE"; then
     log "Freshness token unsealed."
     >"$CACHE_DIR/unseal-success"
@@ -160,7 +160,7 @@ else
     exit 1
 fi
 
-if checkfreshness /tmp/fresh; then
+if checkfreshness "$UNSEALED_SECRET"; then
     log "Freshness token valid, continuing."
 else
     log "Freshness token invalid!"

--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -14,7 +14,6 @@ UNSEALED_SECRET=/tmp/unsealed-secret
 LUKS_HEADER_DUMP=/tmp/luks-header-dump
 LUKS_PCR=13
 
-
 PLYMOUTH_MESSAGES=()
 
 plymouth_message() {
@@ -77,7 +76,7 @@ mkdir -p "$MNT"
 mount -t ext4 -o ro "$DEV" "$MNT"
 
 
-# setup TPM & copy secrets to tmp
+# setup TPM & copy secrets to initrd tmpfs
 
 log "Initializing TPM..."
 modprobe tpm_tis
@@ -87,6 +86,11 @@ log "Copying sealed AEM secrets..."
 cp -Tr "$MNT/aem/${TPMS_DIR##*/}" "${TPMS_DIR}"
 tcsd_changer_identify
 tcsd
+
+SEALED_SECRET_TXT=$TPM_DIR/$LABEL/secret.txt.sealed2
+SEALED_SECRET_KEY=$TPM_DIR/$LABEL/secret.key.sealed2
+SEALED_SECRET_OTP=$TPM_DIR/$LABEL/secret.otp.sealed2
+SEALED_SECRET_FSH=$TPM_DIR/$LABEL/secret.fsh.sealed2
 
 
 # unmount AEM device
@@ -114,18 +118,10 @@ while read luksid; do
 done
 
 
-# set up caches
-
-sealed_secret_txt=$TPM_DIR/$LABEL/secret.txt.sealed2
-sealed_secret_key=$TPM_DIR/$LABEL/secret.key.sealed2
-sealed_secret_otp=$TPM_DIR/$LABEL/secret.otp.sealed2
-sealed_secret_fsh=$TPM_DIR/$LABEL/secret.fsh.sealed2
+# cache suffix and SRK password, if applicable
 
 mkdir -p "$CACHE_DIR"
 echo "${LABEL##$LABEL_PREFIX}" >"$SUFFIX_CACHE"
-
-
-# cache SRK password, if applicable
 
 Z=$(tpm_z_srk)
 
@@ -151,7 +147,7 @@ fi
 # check freshness token
 
 log "Unsealing freshness token..."
-if tpm_unsealdata $Z -i "$sealed_secret_fsh" -o "$UNSEALED_SECRET" \
+if tpm_unsealdata $Z -i "$SEALED_SECRET_FSH" -o "$UNSEALED_SECRET" \
         < "$SRK_PASSWORD_CACHE"; then
     log "Freshness token unsealed."
     >"$CACHE_DIR/unseal-success"
@@ -171,7 +167,7 @@ fi
 # unseal & show OTP if provisioned
 # unseal & decrypt key file unless the user switches to text secret mode
 
-if [ -e "$sealed_secret_otp" ]; then
+if [ -e "$SEALED_SECRET_OTP" ]; then
     alias otp=true
 else
     alias otp=false
@@ -179,7 +175,7 @@ fi
 
 if otp; then
     log "Unsealing TOTP shared secret seed..."
-    if tpm_unsealdata $Z -i "$sealed_secret_otp" -o "$UNSEALED_SECRET" \
+    if tpm_unsealdata $Z -i "$SEALED_SECRET_OTP" -o "$UNSEALED_SECRET" \
             < "$SRK_PASSWORD_CACHE"; then
         log "TOTP secret unsealed."
 
@@ -203,7 +199,7 @@ if otp; then
         } &
         totp_loop_pid=$!
 
-        if tpm_unsealdata $Z -i "$sealed_secret_key" -o "$UNSEALED_SECRET" \
+        if tpm_unsealdata $Z -i "$SEALED_SECRET_KEY" -o "$UNSEALED_SECRET" \
            <"$SRK_PASSWORD_CACHE"; then
             for try in 1 2 3; do
                 pass=$(systemd-ask-password --timeout=0 \
@@ -238,7 +234,7 @@ fi
 
 if ! otp; then
     log "Unsealing text secret..."
-    if tpm_unsealdata $Z -i "$sealed_secret_txt" -o "$UNSEALED_SECRET" \
+    if tpm_unsealdata $Z -i "$SEALED_SECRET_TXT" -o "$UNSEALED_SECRET" \
         <"$SRK_PASSWORD_CACHE"; then
         {
             message ""

--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -188,17 +188,19 @@ if otp; then
 
         seed=$(cat "$UNSEALED_SECRET")
         last=
-        while :; do
+        {
             trap 'plymouth_messages_hide; exit' TERM
-
-            now=$(date +%s)
-            if [ -z "$last" -o "$((now % 30))" = 0 -a "$last" != "$now" ]; then
-                code=$(oathtool --totp -b "$seed")
-                message "[ $(date) ] TOTP code: $code"
-                last=$now
-            fi
-            sleep 0.1
-        done &
+            while :; do
+                now=$(date +%s)
+                if [ -z "$last" ] ||
+                   [ "$((now % 30))" = 0 -a "$last" != "$now" ]; then
+                    code=$(oathtool --totp -b "$seed")
+                    message "[ $(date) ] TOTP code: $code"
+                    last=$now
+                fi
+                sleep 0.1
+            done
+        } &
         totp_loop_pid=$!
 
         if tpm_unsealdata $Z -i "$sealed_secret_key" -o "$UNSEALED_SECRET" \

--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -154,7 +154,7 @@ log "Unsealing freshness token..."
 if tpm_unsealdata $Z -i "$sealed_secret_fsh" -o /tmp/fresh \
         < "$SRK_PASSWORD_CACHE"; then
     log "Freshness token unsealed."
-    touch "$CACHE_DIR/unseal-success"
+    >"$CACHE_DIR/unseal-success"
 else
     log "Freshness token unsealing failed!"
     exit 1

--- a/anti-evil-maid/README
+++ b/anti-evil-maid/README
@@ -249,7 +249,7 @@ AEM media copied/stolen by an attacker
 If you have your system up and running or have an extra AEM media using which
 you can boot the system before the attacker can get to it:
 
-* `sudo su` in dom0
+* `sudo -s` in dom0
 * `. /usr/sbin/anti-evil-maid-lib` (note the dot at the beginning)
 * `revokefreshness <suffix>` (where `<suffix>` is the missing label suffix)
 

--- a/anti-evil-maid/sbin/anti-evil-maid-install
+++ b/anti-evil-maid/sbin/anti-evil-maid-install
@@ -264,9 +264,8 @@ if mfa && [ ! -e "$AEM_DIR/$LABEL/secret.otp" ]; then
         > "$AEM_DIR/$LABEL/secret.otp"
 
     # construct OTP URI
-    otp_label="Qubes%20OS%3A%20Anti%20Evil%20Maid"
     otp_secret="$(cat "$AEM_DIR/$LABEL/secret.otp")"
-    otp_uri="otpauth://totp/${otp_label}?secret=${otp_secret}"
+    otp_uri="otpauth://totp/${LABEL}?secret=${otp_secret}"
 
     # create an ANSI text QR code and show it in the terminal
     echo "$otp_uri" | qrencode -t ansiutf8

--- a/tpm-extra/sbin/tpm_nvread_stdout
+++ b/tpm-extra/sbin/tpm_nvread_stdout
@@ -2,6 +2,5 @@
 # accepts same options as tpm_nvread, except -f
 # writes the NVRAM data read to stdout
 set -e -o pipefail
-export LC_ALL=C
 
 tpm_nvread "$@" -f /dev/stderr 2>&1 1>/dev/null

--- a/tpm-extra/sbin/tpm_nvwrite_stdin
+++ b/tpm-extra/sbin/tpm_nvwrite_stdin
@@ -2,20 +2,8 @@
 # accepts same options as tpm_nvwrite, except -f
 # writes data from stdin into TPM NVRAM
 set -e -o pipefail
-export LC_ALL=C
 
 _tmp=$(mktemp)
-
-# TODO: use `head -c <size>` instead of cat if `-s <size>` or
-#       `--size <size>` passed in order to support /dev/{,u}random
-#        or /dev/zero as inputs
+trap 'rm -f "$_tmp"' EXIT
 cat > "$_tmp"
-
-if tpm_nvwrite "$@" -f "$_tmp"; then
-    _ret=0
-else
-    _ret=1
-fi
-
-rm -f "$_tmp"
-exit "$_ret"
+tpm_nvwrite "$@" -f "$_tmp"


### PR DESCRIPTION
A few more cosmetic patches.

I also noticed that the freshness slot db code could get confused [when given a numeric (0-7) suffix or a suffix that's a substring of an existing suffix](https://github.com/phagara/qubes-antievilmaid/blob/2dbcc8278f5c27a4e20dfb0061c2fcdc6c18ae6c/anti-evil-maid/sbin/anti-evil-maid-lib#L127), or [when given a suffix that includes regex metacharacters](https://github.com/phagara/qubes-antievilmaid/blob/2dbcc8278f5c27a4e20dfb0061c2fcdc6c18ae6c/anti-evil-maid/sbin/anti-evil-maid-lib#L111). The last commit avoids this by simply storing the slot number in a `tpm-freshness-slot` file next to the unsealed secrets.