### PR TITLE
Last one, I think

### DIFF
--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -142,7 +142,7 @@ fi
 if checkfreshness "$UNSEALED_SECRET"; then
     log "Freshness token valid, continuing."
 else
-    message "Freshness token invalid!"
+    log "Freshness token invalid!"
     exit 1
 fi
 

--- a/anti-evil-maid/90anti-evil-maid/module-setup.sh
+++ b/anti-evil-maid/90anti-evil-maid/module-setup.sh
@@ -34,7 +34,6 @@ install() {
         killall \
         lsblk \
         oathtool \
-        od \
         printf \
         scrypt \
         sed \
@@ -56,7 +55,8 @@ install() {
         tr \
         uniq \
         wc \
-        xargs
+        xargs \
+        xxd
 
     dracut_install \
         $systemdsystemunitdir/anti-evil-maid-unseal.service \

--- a/anti-evil-maid/README
+++ b/anti-evil-maid/README
@@ -34,7 +34,7 @@ required dependencies and tools.
 
 b) Verify kernel support for TPM:
 
-# cat /sys/devices/*/*/pcrs
+# cat /sys/class/tpm/tpm0/pcrs
 
 If you see something like this:
 

--- a/anti-evil-maid/sbin/anti-evil-maid-install
+++ b/anti-evil-maid/sbin/anti-evil-maid-install
@@ -200,19 +200,12 @@ fi
 if mfa && [ ! -e "$AEM_DIR/$LABEL/secret.otp" ]; then
     log "Generating new 160-bit TOTP seed"
     mkdir -p "$AEM_DIR/$LABEL"
-    head -c 20 /dev/random \
-        | base32 -w 0 \
-        | tr -d '=' \
-        > "$AEM_DIR/$LABEL/secret.otp"
-
-    # construct OTP URI
-    otp_secret="$(cat "$AEM_DIR/$LABEL/secret.otp")"
-    otp_uri="otpauth://totp/${LABEL}?secret=${otp_secret}"
+    otp_secret=$(head -c 20 /dev/random | base32 -w 0 | tr -d =)
+    echo "$otp_secret" > "$AEM_DIR/$LABEL/secret.otp"
 
     # create an ANSI text QR code and show it in the terminal
+    otp_uri="otpauth://totp/${LABEL}?secret=${otp_secret}"
     echo "$otp_uri" | qrencode -t ansiutf8
-
-    # show QR code
     log "Please scan the above QR code with your OTP device."
 
     # display the text form of secret to user, too

--- a/anti-evil-maid/sbin/anti-evil-maid-lib
+++ b/anti-evil-maid/sbin/anti-evil-maid-lib
@@ -1,4 +1,5 @@
 LABEL_PREFIX=aem
+SYSFS_TPM_DIR=/sys/class/tpm/tpm0
 AEM_DIR=/var/lib/anti-evil-maid
 TPM_DIR=/var/lib/tpm
 TPMS_DIR=${TPM_DIR}s

--- a/anti-evil-maid/sbin/anti-evil-maid-lib
+++ b/anti-evil-maid/sbin/anti-evil-maid-lib
@@ -46,11 +46,11 @@ log() {
 }
 
 hex() {
-    od -A n -v -t x1 | tr -dc 0-9a-f
+    xxd -ps | tr -dc 0-9a-f
 }
 
 unhex() {
-    tr -dc 0-9a-f | sed 's/\(..\)/\\x\1/g' | xargs -0 printf
+    tr -dc 0-9a-f | xxd -ps -r
 }
 
 waitfor() {
@@ -180,7 +180,7 @@ updatefreshness() {
     fi
 
     _pw=$(cat "$TPM_FRESHNESS_PASSWORD_FILE")
-    sha1sum "$1" | cut -d ' ' -f 1 | xxd -r -ps \
+    sha1sum "$1" | cut -d ' ' -f 1 | unhex \
     | tpm_nvwrite_stdin -i "$TPM_FRESHNESS_INDEX" \
       -n "$((_slot * 20))" -s 20 --password="$_pw"
 }

--- a/anti-evil-maid/sbin/anti-evil-maid-seal
+++ b/anti-evil-maid/sbin/anti-evil-maid-seal
@@ -44,7 +44,7 @@ esac
 
 pcrs=$(printf %s "$SEAL" | grep -Eo '\b1[3789]\b') || true
 
-if grep -E "^PCR-(${pcrs//$'\n'/|}):( 00| FF){20}" /sys/devices/*/*/pcrs;
+if grep -E "^PCR-(${pcrs//$'\n'/|}):( 00| FF){20}" "$SYSFS_TPM_DIR"/pcrs;
    [ $? != 1 ]; then
     message "PCR sanity check failed!"
     message "See /usr/share/doc/anti-evil-maid/README for details."

--- a/anti-evil-maid/sbin/anti-evil-maid-tpm-setup
+++ b/anti-evil-maid/sbin/anti-evil-maid-tpm-setup
@@ -15,7 +15,7 @@ if [ "$(id -ur)" != 0 ]; then
     exit 1
 fi
 
-if [ "$(cat /sys/class/tpm/tpm0/owned)" != 0 ]; then
+if [ "$(cat "$SYSFS_TPM_DIR"/owned)" != 0 ]; then
     log "You must reset/clear your TPM chip first!"
     exit 1
 fi

--- a/anti-evil-maid/sbin/anti-evil-maid-tpm-setup
+++ b/anti-evil-maid/sbin/anti-evil-maid-tpm-setup
@@ -23,7 +23,7 @@ fi
 
 # - take ownership of TPM
 
-OWNERPW=$(head -c 16 /dev/random | base64)
+OWNERPW=$(head -c 16 /dev/random | hex)
 lines=( "$OWNERPW" "$OWNERPW" )
 
 if [ $# = 0 ]; then  # set an SRK password

--- a/trousers-changer/sbin/tpm_id
+++ b/trousers-changer/sbin/tpm_id
@@ -31,7 +31,7 @@ getindex() {
 getid() {
     if ! tpm_nvinfo -i "$TPM_ID_INDEX" | grep -q "WRITEDEFINE"; then
         log "TPM NVRAM area at index $TPM_ID_INDEX is not defined!"
-        log "Hint: did you run 'anti-evil-maid-install'?"
+        log "Hint: did you run 'anti-evil-maid-tpm-setup'?"
         echo "unknown"
     else
         tpm_nvread_stdout -i "$TPM_ID_INDEX" | hex

--- a/trousers-changer/sbin/tpm_id
+++ b/trousers-changer/sbin/tpm_id
@@ -21,7 +21,7 @@ log() {
 }
 
 hex() {
-    od -A n -v -t x1 | tr -dc 0-9a-f
+    xxd -ps | tr -dc 0-9a-f
 }
 
 getindex() {


### PR DESCRIPTION
Also:

- Could we actually allow MFA on internal/fixed partitions, i.e. simply drop the `# MFA-specific checks` block from `-install`? It seems at least equal to static AEM in all cases - and superior if the visual observation is coming from an angle where the screen can be seen but not the keyboard.

- Welp, I wonder if anyone (besides me...) will subvocalize `secret.fsh` as "secret [fash](https://en.wiktionary.org/wiki/fash#Etymology_2)" on every resealing. Thoughts on `.fre`?

- https://www.youtube.com/embed/LcmXCXqI7Ew?start=64&end=65